### PR TITLE
コードハイライトを追加

### DIFF
--- a/components/blogContentArea/blogContentArea.tsx
+++ b/components/blogContentArea/blogContentArea.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import { transformDate } from '../format/date'
+import { Blog } from '../../src/types/microCMS'
 import styled from '@emotion/styled'
 
 const TitleAreaDiv = styled.div`
@@ -21,6 +22,9 @@ const TitleAnchor = styled.a`
     display: block;
     margin-top: 8px;
   }
+  &:hover {
+    opacity: 0.5;
+  }
 `
 const PublishedAtDiv = styled.p`
   display: block;
@@ -34,8 +38,30 @@ const PostDiv = styled.div`
     width: 100%;
     border: 2px solid #add8e6;
   }
+  a {
+    color: #0d5297;
+    text-decoration: underline;
+    &:hover {
+      opacity: 0.7;
+      text-decoration: none;
+    }
+  }
   pre {
-    white-space: normal;
+    code {
+      border-radius: 5px;
+    }
+  }
+  ul {
+    list-style: square;
+  }
+  li {
+    code {
+      background-color: #22272e;
+      color: #adbac7;
+      padding: 2px 5px;
+      border-radius: 4px;
+      margin: 0 2px;
+    }
   }
   & > h1 {
     font-size: 30px;
@@ -45,26 +71,27 @@ const PostDiv = styled.div`
     padding: 10px 20px;
     border-radius: 5px;
   }
-
   & > h2 {
     font-size: 24px;
     font-weight: bold;
     margin: 40px 0 16px;
     border-bottom: 1px solid #add8e6;
   }
-
   & > p {
     line-height: 1.8;
     letter-spacing: 0.2px;
   }
-
   & > ol {
     list-style-type: decimal;
     list-style-position: inside;
   }
 `
 
-export default function BlogId({ blog }) {
+type Props = {
+  blog: Blog
+}
+
+export default function BlogId({ blog }: Props) {
   return (
     <div>
       <TitleAreaDiv>
@@ -82,11 +109,7 @@ export default function BlogId({ blog }) {
         : ''
       }
 
-      <PostDiv
-        dangerouslySetInnerHTML={{
-          __html: `${blog.body}`,
-        }}
-      />
+      <PostDiv dangerouslySetInnerHTML={{ __html: blog.body }}/>
     </div>
   );
 }

--- a/components/categoriesBar/categoriesBar.tsx
+++ b/components/categoriesBar/categoriesBar.tsx
@@ -1,14 +1,19 @@
 import styled from '@emotion/styled'
 
 const CategoryAreaDiv = styled.div`
-  background: #4682B4;
   display: flex;
   justify-content: space-between;
-  padding: 4px 36px;
 `
 
 const CategoryAnchor = styled.a`
+  background: #4682B4;
+  width: 25%;
+  padding: 5px 0%;
+  text-align: center;
   color: white;
+  &:hover {
+    opacity: 0.7;
+  }
 `
 export default function CategoriesBar() {
   return (

--- a/components/format/highlight.ts
+++ b/components/format/highlight.ts
@@ -1,0 +1,14 @@
+import cheerio from 'cheerio';
+import hljs from 'highlight.js'
+
+export function formatToHightedHtml(text: string): string {
+  const $ = cheerio.load(text);
+  $('pre code').each((_, elm) => {
+    const languageSubset = ['js', 'html']
+    const result = hljs.highlightAuto($(elm).text(), languageSubset);
+    $(elm).html(result.value);
+    $(elm).addClass('hljs');
+  });
+
+  return $.html()
+}

--- a/components/title/indexTitle.tsx
+++ b/components/title/indexTitle.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled'
 
 const HeaderAreaHeader = styled.header`
   position: relative;
+  height: 250px;
 `
 
 const HeaderAnchor = styled.a`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
+    "cheerio": "^1.0.0-rc.10",
+    "highlight.js": "^11.2.0",
     "microcms-js-sdk": "^1.2.0",
     "next": "11.0.1",
     "react": "17.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css'
+import 'highlight.js/styles/github-dark-dimmed.css';
 
 function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -1,8 +1,9 @@
 import { client } from '../../libs/client'
-import { BlogContentList } from '../../src/types/microCMS'
+import { BlogContentList, Blog } from '../../src/types/microCMS'
 import GeneralTitle from '../../components/title/generalTitle'
 import PageTemplate from '../../components/pageTemplate/pageTemplate'
 import BlogFrameArea from '../../components/blogContentArea/blogFrameArea'
+import { formatToHightedHtml } from '../../components/format/highlight'
 import { GetStaticPropsContext } from 'next';
 
 export default function BlogId({ blog }) {
@@ -27,11 +28,13 @@ export const getStaticPaths = async () => {
 // データをテンプレートに受け渡す部分の処理を記述します
 export const getStaticProps = async (context: GetStaticPropsContext) => {
   const id = context.params.id;
-  const data:BlogContentList = await client.get({ endpoint: "blog", contentId: id.toString() });
+  const data: Blog = await client.get({ endpoint: "blog", contentId: id.toString() });
+
+  data.body = formatToHightedHtml(data.body)
 
   return {
     props: {
-      blog: data,
+      blog: data
     },
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import IndexTitle from '../components/title/indexTitle'
 import PageTemplate from '../components/pageTemplate/pageTemplate'
 import CategoriesBar from '../components/categoriesBar/categoriesBar'
 import BlogFrameArea from '../components/blogContentArea/blogFrameArea'
-import { GetStaticPropsContext } from 'next';
+import { formatToHightedHtml } from '../components/format/highlight'
 
 export default function Home({ blog }) {
   return (
@@ -23,10 +23,14 @@ export default function Home({ blog }) {
 // データをテンプレートに受け渡す部分の処理を記述します
 export const getStaticProps = async () => {
   const data:BlogContentList = await client.get({ endpoint: "blog" });
+  const mappedContents = data.contents.map((content) => {
+    content.body = formatToHightedHtml(content.body)
+    return content
+  })
 
   return {
     props: {
-      blog: data.contents,
+      blog: mappedContents
     },
   };
 };

--- a/src/types/microCMS.ts
+++ b/src/types/microCMS.ts
@@ -14,7 +14,7 @@ revisedAt: string,
 name: string
 }
 
-type Blog = {
+export type Blog = {
   id: string,
   createdAt: string,
   updatedAt: string,
@@ -29,7 +29,6 @@ type Blog = {
 export type BlogContentList = {
   contents: [Blog]
 }
-
 
 export type CategoryContentList = {
   contents: [Category]

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,6 +615,11 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -781,6 +786,30 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+cheerio-select@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
+  integrity sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==
+  dependencies:
+    css-select "^4.1.3"
+    css-what "^5.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+    domutils "^2.7.0"
+
+cheerio@^1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
 
 chokidar@3.5.1:
   version "3.5.1"
@@ -966,6 +995,22 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
+    nth-check "^2.0.0"
+
+css-what@^5.0.0, css-what@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
+
 css.escape@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
@@ -1076,6 +1121,15 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^1.0.1, dom-serializer@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
 domain-browser@4.19.0:
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.19.0.tgz#1093e17c0a17dbd521182fe90d49ac1370054af1"
@@ -1085,6 +1139,27 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.5.2, domutils@^2.6.0, domutils@^2.7.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 electron-to-chromium@^1.3.723:
   version "1.3.772"
@@ -1132,6 +1207,11 @@ enquirer@^2.3.5:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1653,6 +1733,11 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+highlight.js@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.2.0.tgz#a7e3b8c1fdc4f0538b93b2dc2ddd53a40c6ab0f0"
+  integrity sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -1673,6 +1758,16 @@ hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-errors@1.7.3:
   version "1.7.3"
@@ -2293,6 +2388,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nth-check@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+  dependencies:
+    boolbase "^1.0.0"
+
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2463,6 +2565,18 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -3255,6 +3369,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
# 概要
- #1 対処としてコードハイライトを追加
- +α
  - 文章内のaタグに固有スタイルとhoverスタイルを追加
  - タイトルのaタグにhoverスタイルを追加
  - カテゴリのaタグにhoverスタイルを追加

# 見た目の変化
- 元々
  - ![スクリーンショット 2021-09-23 16 55 22](https://user-images.githubusercontent.com/47911711/134523149-bacfea28-dfbf-413e-9167-7777e73dfd39.png)
- その後
  - ![スクリーンショット 2021-09-23 23 12 43](https://user-images.githubusercontent.com/47911711/134523294-32a96c7f-9466-40ab-90ad-86b65b02010a.png)

# ざっくり詳細
- [参考サイト](https://qiita.com/cawauchi/items/ff6489b17800c5676908)
- highlight.jsを利用
- prism.jsを利用するつもりだったが、prism.jsによって吐き出されるコードが`dangerouslySetInnerHTML`によってエラー判定されてしまうためhighlight.jsに変更した。
  - はっきりとした原因は解明できていないが、prism.jsを切ったらエラーはでなくなったため、prism.jsによる変換が原因でほぼ確定と思われる。変換後のエラーを出している箇所を解明しても、useEffectでprism.jsを発火させた後にさらにコードを整形することになり煩雑になりすぎるため、別ライブラリを試すことにした。